### PR TITLE
When set use ${EDITOR} instead of vim to edit notes

### DIFF
--- a/fuz
+++ b/fuz
@@ -242,7 +242,7 @@ function _open_filematch() {
 
     if [[ $edit == 1 ]]; then
       # Vim mouse-mode, start at top, softwrap, no numbering/highlight, clipboard copy-paste
-      vim \
+      ${EDITOR:-vim} \
         +":set mouse=a" +":silent! normal g;" \
         +":set number nohlsearch" \
         +":set wrap linebreak nolist" \
@@ -296,7 +296,7 @@ function main() {
 
     # Touch and open with system if --open flag, else use vim
     if [[ $edit -eq 1 ]]; then
-      vim "$file"
+      ${EDITOR:-vim} "$file"
     else
       touch "$file"
       open "$file"

--- a/fuz_scripts.sh
+++ b/fuz_scripts.sh
@@ -42,7 +42,7 @@ function _fze_write() {
   linematch=${2:-0}
   if [[ -f $file ]]; then
     # Vim mouse-mode, start at top, softwrap, no numbering/highlight, clipboard copy-paste
-    vim \
+    ${EDITOR:-vim} \
       +":set mouse=a" +":silent! normal g;" \
       +":set number nohlsearch" \
       +":set wrap linebreak nolist" \
@@ -82,7 +82,7 @@ function _fz_write() {
   # If valid file, open with vim if edit (-e) flag, else less
   if [[ -f $file ]]; then
     # Vim mouse-mode, start at top, softwrap, no numbering/highlight, clipboard copy-paste
-    vim \
+    ${EDITOR:-vim} \
       +":set mouse=a" +":silent! normal g;" \
       +":set number nohlsearch" \
       +":set wrap linebreak nolist" \

--- a/fuz_scripts.sh
+++ b/fuz_scripts.sh
@@ -42,7 +42,7 @@ function _fze_write() {
   linematch=${2:-0}
   if [[ -f $file ]]; then
     # Vim mouse-mode, start at top, softwrap, no numbering/highlight, clipboard copy-paste
-    ${EDITOR:-vim} \
+    "${FUZ_EDITOR:-vim}" \
       +":set mouse=a" +":silent! normal g;" \
       +":set number nohlsearch" \
       +":set wrap linebreak nolist" \
@@ -82,7 +82,7 @@ function _fz_write() {
   # If valid file, open with vim if edit (-e) flag, else less
   if [[ -f $file ]]; then
     # Vim mouse-mode, start at top, softwrap, no numbering/highlight, clipboard copy-paste
-    ${EDITOR:-vim} \
+    "${FUZ_EDITOR:-vim}" \
       +":set mouse=a" +":silent! normal g;" \
       +":set number nohlsearch" \
       +":set wrap linebreak nolist" \


### PR DESCRIPTION
Take it or leave it, this change is so I can use neovim instead of vim to edit notes.  I could not find any tests in the repository to modify.  Please advise if you need to test this somehow.

```bash
export EDITOR=vim
```

Use `${EDITOR}` when someone sets it instead of vim.  For example, this lets the user select neovim or macvim instead.
A larger change is needed to not pass vim-like command line arguments by default.  This is an issue should the user select nano, pico, babi, etc as their preferred editor.

