### PR TITLE
Ensure subdirectory exists when creating a new note

### DIFF
--- a/fuz
+++ b/fuz
@@ -296,8 +296,10 @@ function main() {
 
     # Touch and open with system if --open flag, else use vim
     if [[ $edit -eq 1 ]]; then
+      mkdir -p "$(dirname "$file")"
       vim "$file"
     else
+      mkdir -p "$(dirname "$file")"
       touch "$file"
       open "$file"
     fi


### PR DESCRIPTION
This allows the user to create new notes in subdirectories of the --path.

For example,

```bash
fuz --path /path/to/notebook --create /subsection/note.md
```

The above command will now create a note in `/path/to/notebook/subsection/note.md`.

