### PR TITLE
Ensure new notes have the desired extension when setting the ${NOTE_EXT}

### DIFF
--- a/fuz
+++ b/fuz
@@ -293,9 +293,9 @@ function main() {
     fi
     file="$dir/$query"
 
-    # Ensure notes have valid note extension
-    if [[ -z ${NOTE_EXT} ]]; then
-      if ! [[ $file =~ .*\.(md|txt|rst|adoc|json|jsn|yaml|yml|MD|TXT|RST|ADOC|JSON|JSN|YAML|YML) ]]; then
+    # Ensure notes have valid note extension when NOTE_EXT is set
+    if ! [[ -z ${NOTE_EXT} ]]; then
+      if ! [[ ${file,,} =~ .*\.(md|txt|rst|adoc|json|jsn|yaml|yml)$ ]]; then
         file="${file%.*}.${NOTE_EXT#.}"
       fi
     fi

--- a/fuz
+++ b/fuz
@@ -292,6 +292,13 @@ function main() {
       die "No filename provided to --create [FILENAME]"
     fi
     file="$dir/$query"
+
+    # Ensure notes have valid note extension
+    if [[ -z ${NOTE_EXT} ]]; then
+      if ! [[ $file =~ .*\.(md|txt|rst|adoc|MD|TXT|RST|ADOC) ]]; then
+        file="${file%.*}.${NOTE_EXT#.}"
+      fi
+    fi
     msg "$dir/$file"
 
     # Touch and open with system if --open flag, else use vim

--- a/fuz
+++ b/fuz
@@ -295,7 +295,7 @@ function main() {
 
     # Ensure notes have valid note extension
     if [[ -z ${NOTE_EXT} ]]; then
-      if ! [[ $file =~ .*\.(md|txt|rst|adoc|MD|TXT|RST|ADOC) ]]; then
+      if ! [[ $file =~ .*\.(md|txt|rst|adoc|json|jsn|yaml|yml|MD|TXT|RST|ADOC|JSON|JSN|YAML|YML) ]]; then
         file="${file%.*}.${NOTE_EXT#.}"
       fi
     fi


### PR DESCRIPTION
For example, if we set `export NOTE_EXT=.md` or run `NOTE_EXT=.md fuz --create blah`, then `/path/to/notebook/blah.md` will be created instead of `/path/to/notebook/blah`.
Additionally, this logic is ignored if an explicit text-like extension is supplied to the `--create` argument.

