### PR TITLE
Fix content search matching only some lines

### DIFF
--- a/fuz
+++ b/fuz
@@ -349,10 +349,11 @@ function main() {
   # Uses ripgrep with line numbers + filenames. Ignores binary files and .git
   # FZF shows file-content previews. Auto-selects if single match
   # Hack: $fuzzysearch unquoted to allow for empty string (fzf breaks with "" as input)
+  # rg search unicode letter \p{Letter}: https://docs.rs/regex/1.10.4/regex/#syntax
   # Bindings: Ctrl + E to edit with vim, Ctrl + L to open with less
   else
     filematch=$(
-      rg ".*\\p{L}" --max-columns 250 --max-columns-preview \
+      rg ".*\p{Letter}" --max-columns 250 --max-columns-preview \
         --color=always --no-heading --with-filename --line-number \
         --max-depth "$maxdepth" --max-filesize "$maxsize" --max-count "$maxlines" \
         ${rg_sort:-} \

--- a/fuz
+++ b/fuz
@@ -352,7 +352,7 @@ function main() {
   # Bindings: Ctrl + E to edit with vim, Ctrl + L to open with less
   else
     filematch=$(
-      rg ".*[:alpha:]" --max-columns 250 --max-columns-preview \
+      rg ".*\\p{L}" --max-columns 250 --max-columns-preview \
         --color=always --no-heading --with-filename --line-number \
         --max-depth "$maxdepth" --max-filesize "$maxsize" --max-count "$maxlines" \
         ${rg_sort:-} \


### PR DESCRIPTION
Hi @Magnushhoie,

I was using fuz with Greek texts and I couldn't figure out why it would only return a subset of the occurrences.

Digging into the source, I noticed the `.*[:alpha:]` regex filter on rg (introduced [here](https://github.com/Magnushhoie/fuz/commit/a67e36ccd97706a08214849ccf174ebded0a30b1#diff-fd45a1e4147319a781bfaa72961cc3e8c6693c9da204852f65e433a87b85f3e0R127)). It was not only ignoring non-Latin characters but also only matching lines that contained any of the a, l, p, h letters or a colon (`[:alpha:]` being a typo of the class `[[:alpha:]]` :stuck_out_tongue:).

The PR replaces it with `.*\p{L}` where the Unicode letter class `\p{L}` should cover all alphabets. I think your previous choice of `^\S` would also work fine though.

Thank you for this great tool!